### PR TITLE
Feature: Allow YAML multiple documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# JSON and YAML - Validator ✅
+# JSON and YAML - Validator ✅ 
 
 [![CodeQL](https://github.com/grantbirki/json-yaml-validate/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/grantbirki/json-yaml-validate/actions/workflows/codeql-analysis.yml) [![test](https://github.com/grantbirki/json-yaml-validate/actions/workflows/test.yml/badge.svg)](https://github.com/grantbirki/json-yaml-validate/actions/workflows/test.yml) [![acceptance-test](https://github.com/GrantBirki/json-yaml-validate/actions/workflows/acceptance-test.yml/badge.svg)](https://github.com/GrantBirki/json-yaml-validate/actions/workflows/acceptance-test.yml) [![package-check](https://github.com/grantbirki/json-yaml-validate/actions/workflows/package-check.yml/badge.svg)](https://github.com/grantbirki/json-yaml-validate/actions/workflows/package-check.yml) [![lint](https://github.com/grantbirki/json-yaml-validate/actions/workflows/lint.yml/badge.svg)](https://github.com/grantbirki/json-yaml-validate/actions/workflows/lint.yml) [![coverage](./badges/coverage.svg)](./badges/coverage.svg)
 

--- a/__tests__/fixtures/yaml/multiple/invalid.yaml
+++ b/__tests__/fixtures/yaml/multiple/invalid.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+# spec:
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx: service
+  labels:
+    app: nginx
+# spec:

--- a/__tests__/fixtures/yaml/multiple/yaml1.yaml
+++ b/__tests__/fixtures/yaml/multiple/yaml1.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+  labels:
+    app: nginx
+# spec:
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+  labels:
+    app: nginx
+# spec:

--- a/__tests__/functions/yaml-validator.test.js
+++ b/__tests__/functions/yaml-validator.test.js
@@ -112,7 +112,8 @@ test('fails to validate a yaml file without using a schema', async () => {
         errors: [
           {
             path: null,
-            message: 'Invalid YAML'
+            message: 'Invalid YAML',
+            error: "YAMLParseError Nested mappings are not allowed in compact mappings at line 4, column 17"
           }
         ]
       }
@@ -252,7 +253,8 @@ test('successfully validates a yaml file with multiple documents but fails on th
       errors: [
         {
           path: null,
-          message: 'Invalid YAML'
+          message: 'Invalid YAML',
+          error: 'YAMLParseError Nested mappings are not allowed in compact mappings at line 13, column 9'
         }
       ]
     }]

--- a/__tests__/functions/yaml-validator.test.js
+++ b/__tests__/functions/yaml-validator.test.js
@@ -23,6 +23,7 @@ beforeEach(() => {
   process.env.INPUT_YAML_AS_JSON = false
   process.env.INPUT_USE_DOT_MATCH = 'true'
   process.env.INPUT_FILES = ''
+  process.env.INPUT_ALLOW_MULTIPLE_DOCUMENTS = 'false'
 })
 
 test('successfully validates a yaml file with a schema', async () => {
@@ -235,5 +236,33 @@ test('skips all files when yaml_as_json is true, even invalid ones', async () =>
   )
   expect(debugMock).toHaveBeenCalledWith(
     'skipping yaml since it should be treated as json: __tests__/fixtures/yaml/invalid/skip-bad.yaml'
+  )
+})
+
+test('successfully validates a yaml file with multiple documents but fails on the other', async () => {
+  process.env.INPUT_ALLOW_MULTIPLE_DOCUMENTS = 'true'
+  process.env.INPUT_BASE_DIR = '__tests__/fixtures/yaml/multiple'
+  expect(await yamlValidator(excludeMock)).toStrictEqual({
+    failed: 1,
+    passed: 1,
+    skipped: 0,
+    success: false,
+    violations: [{
+      file: '__tests__/fixtures/yaml/multiple/invalid.yaml',
+      errors: [
+        {
+          path: null,
+          message: 'Invalid YAML'
+        }
+      ]
+    }]
+  })
+  expect(infoMock).toHaveBeenCalledWith(
+    `multiple documents found in file: __tests__/fixtures/yaml/multiple/yaml1.yaml`
+  )
+  expect(errorMock).toHaveBeenCalledWith(
+    expect.stringMatching(
+      '❌ failed to parse YAML file: __tests__/fixtures/yaml/multiple/invalid.yaml'
+    )
   )
 })

--- a/__tests__/functions/yaml-validator.test.js
+++ b/__tests__/functions/yaml-validator.test.js
@@ -113,7 +113,8 @@ test('fails to validate a yaml file without using a schema', async () => {
           {
             path: null,
             message: 'Invalid YAML',
-            error: "YAMLParseError Nested mappings are not allowed in compact mappings at line 4, column 17"
+            error:
+              'YAMLParseError Nested mappings are not allowed in compact mappings at line 4, column 17'
           }
         ]
       }
@@ -248,16 +249,19 @@ test('successfully validates a yaml file with multiple documents but fails on th
     passed: 1,
     skipped: 0,
     success: false,
-    violations: [{
-      file: '__tests__/fixtures/yaml/multiple/invalid.yaml',
-      errors: [
-        {
-          path: null,
-          message: 'Invalid YAML',
-          error: 'YAMLParseError Nested mappings are not allowed in compact mappings at line 13, column 9'
-        }
-      ]
-    }]
+    violations: [
+      {
+        file: '__tests__/fixtures/yaml/multiple/invalid.yaml',
+        errors: [
+          {
+            path: null,
+            message: 'Invalid YAML',
+            error:
+              'YAMLParseError Nested mappings are not allowed in compact mappings at line 13, column 9'
+          }
+        ]
+      }
+    ]
   })
   expect(infoMock).toHaveBeenCalledWith(
     `multiple documents found in file: __tests__/fixtures/yaml/multiple/yaml1.yaml`

--- a/action.yml
+++ b/action.yml
@@ -81,6 +81,10 @@ inputs:
     description: The full path to the .gitignore file to use if use_gitignore is set to "true" (e.g. ./src/.gitignore) - Default is ".gitignore" which uses the .gitignore file in the root of the repository
     required: false
     default: ".gitignore"
+  allow_multiple_documents:
+    description: Whether or not to allow multiple documents in a single YAML file - "true" or "false" - Default is "false"
+    required: false
+    default: "false"
 outputs:
   success:
     description: Whether or not the validation was successful for all files - "true" or "false"

--- a/src/functions/yaml-validator.js
+++ b/src/functions/yaml-validator.js
@@ -2,7 +2,7 @@ import * as core from '@actions/core'
 import validateSchema from 'yaml-schema-validator'
 import {readFileSync} from 'fs'
 import {fdir} from 'fdir'
-import {parse,parseAllDocuments} from 'yaml'
+import {parse, parseAllDocuments} from 'yaml'
 
 // Helper function to validate all yaml files in the baseDir
 export async function yamlValidator(exclude) {
@@ -13,7 +13,9 @@ export async function yamlValidator(exclude) {
   const yamlExcludeRegex = core.getInput('yaml_exclude_regex')
   const yamlAsJson = core.getBooleanInput('yaml_as_json')
   const useDotMatch = core.getBooleanInput('use_dot_match')
-  const allowMultipleDocuments = core.getBooleanInput('allow_multiple_documents')
+  const allowMultipleDocuments = core.getBooleanInput(
+    'allow_multiple_documents'
+  )
   let files = core.getMultilineInput('files').filter(Boolean)
 
   // remove trailing slash from baseDir
@@ -89,21 +91,20 @@ export async function yamlValidator(exclude) {
     try {
       // try to parse the yaml file
       if (allowMultipleDocuments) {
-          let documents = parseAllDocuments(readFileSync(fullPath, 'utf8'))
-          for (let doc of documents) {
-            if (doc.errors.length > 0) {
-              // format and show the first error
-              throw doc.errors[0]
-            }
-            parse(doc.toString()) // doc.toString() will throw an error if the document is invalid
+        let documents = parseAllDocuments(readFileSync(fullPath, 'utf8'))
+        for (let doc of documents) {
+          if (doc.errors.length > 0) {
+            // format and show the first error
+            throw doc.errors[0]
           }
-          core.info(`multiple documents found in file: ${fullPath}`)
-          multipleDocuments = true
-      } 
-      else {
+          parse(doc.toString()) // doc.toString() will throw an error if the document is invalid
+        }
+        core.info(`multiple documents found in file: ${fullPath}`)
+        multipleDocuments = true
+      } else {
         parse(readFileSync(fullPath, 'utf8'))
       }
-    } catch(err) {
+    } catch (err) {
       // if the yaml file is invalid, log an error and set success to false
       core.error(`❌ failed to parse YAML file: ${fullPath}`)
       result.success = false


### PR DESCRIPTION
This feature allows YAML validator to be able to parse multiple documents. 

Currently came up with a simple solution: if fails to parse a file `parse` which allows only single document YAML, will try to parse it as multiple documents if `allow_multiple_documents` flag is `true`, and then try to parse each document again.

Have plenty of room for features
- validate with schema ?
  - how strict ?
- more flags or options about multi document parsing
- more info logged from getting error when parsing

p.s. will need assist on the process of building for release 