### PR TITLE
Harden unit test coverage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -358,6 +358,19 @@ For behavior changes, prefer adding or modifying fixtures under
 Tiny temporary files are used in a few edge-case tests today, but fixtures are
 easier to audit and safer for future maintenance.
 
+When replacing discovery dependencies, keep the hardened unit tests around these
+behaviors green:
+
+- explicit `files` input bypasses `base_dir` and validates matching files from
+  anywhere in the workspace
+- if `files` is provided but all glob patterns are unmatched, validators fall
+  back to crawler discovery under `base_dir`
+- custom JSON and YAML extensions are discovered through crawler mode
+- `yaml_as_json` parse failures are reported as `Invalid JSON` for
+  compatibility
+- multi-document YAML syntax validation skips native YAML schema validation
+- custom exclude files use gitignore-style negation and directory patterns
+
 ## CI Workflows
 
 - `test.yml`: installs with `npm ci` and runs `npm run ci-test`.

--- a/__tests__/functions/exclude.test.js
+++ b/__tests__/functions/exclude.test.js
@@ -99,3 +99,32 @@ test('fails to read the .gitignore file', () => {
     `error reading .gitignore file: Error: ENOENT: no such file or directory, open 'does-not-exist'`
   )
 })
+
+test('supports gitignore-style negation in custom exclude files', () => {
+  const fs = require('fs')
+  const os = require('os')
+  const path = require('path')
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'exclude-negation-'))
+  const tempFile = path.join(tempDir, 'exclude.txt')
+  fs.writeFileSync(tempFile, '*.json\n!important.json\nnested/\n')
+
+  process.env.INPUT_EXCLUDE_FILE = tempFile
+  process.env.INPUT_USE_GITIGNORE = 'false'
+
+  const exclude = new Exclude()
+  expect(exclude.isExcluded('skip.json')).toBe(true)
+  expect(exclude.isExcluded('important.json')).toBe(false)
+  expect(exclude.isExcluded('nested/file.yaml')).toBe(true)
+
+  fs.rmSync(tempDir, {recursive: true, force: true})
+})
+
+test('does not read git_ignore_path when use_gitignore is false', () => {
+  process.env.INPUT_EXCLUDE_FILE = ''
+  process.env.INPUT_USE_GITIGNORE = 'false'
+  process.env.INPUT_GIT_IGNORE_PATH = 'does-not-exist'
+
+  const exclude = new Exclude()
+  expect(exclude.isExcluded('tmp/test.json')).toBe(false)
+  expect(warningMock).not.toHaveBeenCalled()
+})

--- a/__tests__/functions/json-validator.test.js
+++ b/__tests__/functions/json-validator.test.js
@@ -930,3 +930,106 @@ test('edge case: malformed JSON in real file', async () => {
   // Cleanup
   fs.unlinkSync(tempFile)
 })
+
+test('falls back to base_dir discovery when explicit json file globs match nothing', async () => {
+  process.env.INPUT_JSON_SCHEMA = ''
+  process.env.INPUT_FILES = '__tests__/fixtures/does-not-exist/**/*.json'
+  process.env.INPUT_BASE_DIR = '__tests__/fixtures/json/valid'
+
+  expect(await jsonValidator(excludeMock)).toStrictEqual({
+    failed: 0,
+    passed: 1,
+    skipped: 0,
+    success: true,
+    violations: []
+  })
+})
+
+test('files input validates json outside base_dir', async () => {
+  process.env.INPUT_JSON_SCHEMA = ''
+  process.env.INPUT_BASE_DIR = '__tests__/fixtures/yaml/valid'
+  process.env.INPUT_FILES = '__tests__/fixtures/json/valid/json1.json'
+
+  expect(await jsonValidator(excludeMock)).toStrictEqual({
+    failed: 0,
+    passed: 1,
+    skipped: 0,
+    success: true,
+    violations: []
+  })
+})
+
+test('discovers json files with a custom extension', async () => {
+  const fs = require('fs')
+  const os = require('os')
+  const path = require('path')
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'json-custom-ext-'))
+  const tempFile = path.join(tempDir, 'config.jsonc')
+  fs.writeFileSync(tempFile, '{"foo": 1}')
+
+  process.env.INPUT_JSON_SCHEMA = ''
+  process.env.INPUT_JSON_EXTENSION = '.jsonc'
+  process.env.INPUT_BASE_DIR = tempDir
+
+  expect(await jsonValidator(excludeMock)).toStrictEqual({
+    failed: 0,
+    passed: 1,
+    skipped: 0,
+    success: true,
+    violations: []
+  })
+
+  fs.rmSync(tempDir, {recursive: true, force: true})
+})
+
+test('yaml_as_json reports invalid yaml parse errors as invalid json', async () => {
+  const fs = require('fs')
+  const os = require('os')
+  const path = require('path')
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'yaml-as-json-bad-'))
+  const tempFile = path.join(tempDir, 'bad.yaml')
+  fs.writeFileSync(tempFile, 'person: { name: mona: lisa }')
+
+  process.env.INPUT_JSON_SCHEMA = ''
+  process.env.INPUT_YAML_AS_JSON = 'true'
+  process.env.INPUT_BASE_DIR = tempDir
+
+  expect(await jsonValidator(excludeMock)).toStrictEqual({
+    failed: 1,
+    passed: 0,
+    skipped: 0,
+    success: false,
+    violations: [
+      {
+        file: tempFile,
+        errors: [
+          {
+            path: null,
+            message: 'Invalid JSON'
+          }
+        ]
+      }
+    ]
+  })
+
+  fs.rmSync(tempDir, {recursive: true, force: true})
+})
+
+test('json schema path is skipped when discovered through explicit files', async () => {
+  process.env.INPUT_JSON_SCHEMA = '__tests__/fixtures/schemas/schema1.json'
+  process.env.INPUT_FILES =
+    '__tests__/fixtures/schemas/schema1.json\n__tests__/fixtures/json/valid/json1.json'
+  process.env.INPUT_BASE_DIR = '__tests__/fixtures/json/invalid'
+
+  expect(await jsonValidator(excludeMock)).toStrictEqual({
+    failed: 0,
+    passed: 1,
+    skipped: 0,
+    success: true,
+    violations: []
+  })
+
+  expect(debugMock).toHaveBeenCalledWith(
+    'skipping json schema file: __tests__/fixtures/schemas/schema1.json'
+  )
+})

--- a/__tests__/functions/process-results.test.js
+++ b/__tests__/functions/process-results.test.js
@@ -7,6 +7,7 @@ const warningMock = jest.spyOn(core, 'warning').mockImplementation(() => {})
 const errorMock = jest.spyOn(core, 'error').mockImplementation(() => {})
 const setFailedMock = jest.spyOn(core, 'setFailed').mockImplementation(() => {})
 const setOutputMock = jest.spyOn(core, 'setOutput').mockImplementation(() => {})
+const createCommentMock = jest.fn()
 
 const jsonViolations = [
   {
@@ -74,7 +75,7 @@ beforeEach(() => {
     return {
       rest: {
         issues: {
-          createComment: jest.fn().mockReturnValueOnce({
+          createComment: createCommentMock.mockReturnValueOnce({
             data: {}
           })
         }
@@ -285,6 +286,75 @@ test('tests constructBody function with JSON failures only (covers lines 50-67)'
   expect(infoMock).toHaveBeenCalledWith(
     expect.stringMatching('📝 adding comment to PR')
   )
+})
+
+test('does not comment when comment mode is enabled outside a pull request', async () => {
+  process.env.INPUT_COMMENT = 'true'
+  github.context.payload = {
+    push: {
+      ref: 'refs/heads/main'
+    }
+  }
+
+  expect(
+    await processResults(
+      {
+        success: false,
+        failed: 1,
+        passed: 0,
+        skipped: 0,
+        violations: jsonViolations
+      },
+      {success: true, failed: 0, passed: 1, skipped: 0, violations: []}
+    )
+  ).toBe(false)
+
+  expect(github.getOctokit).not.toHaveBeenCalled()
+  expect(createCommentMock).not.toHaveBeenCalled()
+  expect(setFailedMock).toHaveBeenCalledWith(
+    '❌ JSON or YAML files failed validation'
+  )
+})
+
+test('constructs a pull request comment body with both violation sections', async () => {
+  process.env.INPUT_COMMENT = 'true'
+
+  expect(
+    await processResults(
+      {
+        success: false,
+        failed: 2,
+        passed: 1,
+        skipped: 3,
+        violations: jsonViolations
+      },
+      {
+        success: false,
+        failed: 1,
+        passed: 4,
+        skipped: 5,
+        violations: yamlViolations
+      }
+    )
+  ).toBe(false)
+
+  expect(createCommentMock).toHaveBeenCalledWith({
+    owner: 'corp',
+    repo: 'test',
+    issue_number: 123,
+    body: expect.stringContaining('## JSON and YAML Validation Results')
+  })
+  const commentBody = createCommentMock.mock.calls[0][0].body
+  expect(commentBody).toContain('### JSON Validation Results')
+  expect(commentBody).toContain('- ✅ File(s) Passed: 1')
+  expect(commentBody).toContain('- ❌ File(s) Failed: 2')
+  expect(commentBody).toContain('- ⏭️ File(s) Skipped: 3')
+  expect(commentBody).toContain(JSON.stringify(jsonViolations, null, 2))
+  expect(commentBody).toContain('### YAML Validation Results')
+  expect(commentBody).toContain('- ✅ File(s) Passed: 4')
+  expect(commentBody).toContain('- ❌ File(s) Failed: 1')
+  expect(commentBody).toContain('- ⏭️ File(s) Skipped: 5')
+  expect(commentBody).toContain(JSON.stringify(yamlViolations, null, 2))
 })
 
 test('tests constructBody function with YAML failures only (covers lines 69-86)', async () => {

--- a/__tests__/functions/yaml-validator.test.js
+++ b/__tests__/functions/yaml-validator.test.js
@@ -456,3 +456,83 @@ test('skips json files when yaml_as_json is false', async () => {
     "the yaml-validator found a json file so it will be skipped here: '__tests__/fixtures/json/valid/json1.json'"
   )
 })
+
+test('falls back to base_dir discovery when explicit yaml file globs match nothing', async () => {
+  process.env.INPUT_FILES = '__tests__/fixtures/does-not-exist/**/*.yaml'
+  process.env.INPUT_BASE_DIR = '__tests__/fixtures/yaml/valid'
+
+  expect(await yamlValidator(excludeMock)).toStrictEqual({
+    failed: 0,
+    passed: 1,
+    skipped: 0,
+    success: true,
+    violations: []
+  })
+})
+
+test('files input validates yaml outside base_dir', async () => {
+  process.env.INPUT_YAML_SCHEMA = ''
+  process.env.INPUT_BASE_DIR = '__tests__/fixtures/json/valid'
+  process.env.INPUT_FILES = '__tests__/fixtures/yaml/valid/yaml1.yaml'
+
+  expect(await yamlValidator(excludeMock)).toStrictEqual({
+    failed: 0,
+    passed: 1,
+    skipped: 0,
+    success: true,
+    violations: []
+  })
+})
+
+test('discovers yaml files with custom extensions', async () => {
+  const fs = require('fs')
+  const os = require('os')
+  const path = require('path')
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'yaml-custom-ext-'))
+  fs.writeFileSync(path.join(tempDir, 'config.yamlx'), 'person:\n  age: 1')
+  fs.writeFileSync(path.join(tempDir, 'other.ymlx'), 'person:\n  age: 2')
+
+  process.env.INPUT_YAML_SCHEMA = ''
+  process.env.INPUT_YAML_EXTENSION = '.yamlx'
+  process.env.INPUT_YAML_EXTENSION_SHORT = '.ymlx'
+  process.env.INPUT_BASE_DIR = tempDir
+
+  expect(await yamlValidator(excludeMock)).toStrictEqual({
+    failed: 0,
+    passed: 2,
+    skipped: 0,
+    success: true,
+    violations: []
+  })
+
+  fs.rmSync(tempDir, {recursive: true, force: true})
+})
+
+test('multi-document yaml skips schema validation after syntax validation', async () => {
+  process.env.INPUT_ALLOW_MULTIPLE_DOCUMENTS = 'true'
+  process.env.INPUT_YAML_SCHEMA = '__tests__/fixtures/schemas/schema2.yml'
+  process.env.INPUT_FILES = '__tests__/fixtures/yaml/multiple/yaml1.yaml'
+  process.env.INPUT_BASE_DIR = '.'
+
+  expect(await yamlValidator(excludeMock)).toStrictEqual({
+    failed: 0,
+    passed: 1,
+    skipped: 0,
+    success: true,
+    violations: []
+  })
+})
+
+test('yaml_as_json causes explicit json files to be counted as skipped by yaml validator', async () => {
+  process.env.INPUT_YAML_AS_JSON = 'true'
+  process.env.INPUT_FILES = '__tests__/fixtures/json/valid/json1.json'
+  process.env.INPUT_BASE_DIR = '.'
+
+  expect(await yamlValidator(excludeMock)).toStrictEqual({
+    failed: 0,
+    passed: 0,
+    skipped: 1,
+    success: true,
+    violations: []
+  })
+})


### PR DESCRIPTION
Adds broader unit coverage around validator discovery, YAML-as-JSON handling, exclude rules, and PR comment formatting before dependency slimming.