### PR TITLE
Pin workflow action references

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Need to checkout for testing the Action in this repo
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
 
       # creates invalid files that are excluded by git and should not fail
       - name: invalid file creation

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,10 +10,10 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
 
       - name: setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # pin@v6
         with:
           node-version-file: .node-version
           cache: 'npm'

--- a/.github/workflows/package-check.yml
+++ b/.github/workflows/package-check.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
 
       - name: setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # pin@v6
         with:
           node-version-file: .node-version
           cache: 'npm'
@@ -37,7 +37,7 @@ jobs:
         id: diff
 
       # If index.js was different than expected, upload the expected version as an artifact
-      - uses: actions/upload-artifact@v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # pin@v7
         if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         with:
           name: dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
 
       - name: setup node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # pin@v6
         with:
           node-version-file: .node-version
           cache: 'npm'

--- a/.github/workflows/update-latest-release-tag.yml
+++ b/.github/workflows/update-latest-release-tag.yml
@@ -20,7 +20,7 @@ jobs:
   tag:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # pin@v6
         with:
           fetch-depth: 0
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -410,12 +410,15 @@ directory.
   formats, flat YAML schemas, multi-document YAML-as-JSON, Helm-chart
   exclusions, custom extensions, exclude-file negation, warn mode, and
   expected-failure checks for invalid syntax and schema errors.
-- `codeql-analysis.yml`: JavaScript/TypeScript CodeQL scan on `main` and weekly
-  schedule.
 - `update-latest-release-tag.yml`: manual workflow to force-update major
-  release tags such as `v8`.
-- `copilot-setup-steps.yml`: setup workflow for Copilot-style coding agents.
+  release tags such as `v4`.
 - `.github/dependabot.yml`: monthly grouped updates for GitHub Actions and npm.
+
+Executable workflow action refs should be pinned to full-length commit SHAs with
+`gh pin -mode actions`. The `# pin@vN` comments record the major tag that was
+resolved. When refreshing Actions, update docs/examples to the latest major tag,
+temporarily update workflow refs to that tag, then run `gh pin -mode actions
+.github/workflows/<file>.yml` for each workflow file.
 
 CI is the source of truth for package freshness. Any source change that affects
 runtime code should include the regenerated bundle before a PR is considered
@@ -562,6 +565,15 @@ Updating dependencies:
 3. Run `npm run all`.
 4. Inspect `dist/licenses.txt` and the generated bundle diff for unexpected
    dependency churn.
+
+Updating GitHub Actions:
+
+1. Check the current upstream major tags for each referenced action.
+2. Update user-facing README examples to the latest major tag.
+3. Update workflow refs to the latest major tag, then run `gh pin -mode actions`
+   against each workflow so executable refs end as full commit SHAs.
+4. Sweep `.github/workflows/` for any remaining unpinned third-party `uses:`
+   entries before opening a PR.
 
 Preparing a PR:
 

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ Here is a quick example of how to install this action in any workflow:
 
 ```yaml
 # checkout the repository (required for this Action to work)
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 
 # validate JSON and YAML files
 - name: json-yaml-validate
-  uses: GrantBirki/json-yaml-validate@vX.X.X # <--- replace with the latest version
+  uses: GrantBirki/json-yaml-validate@v4
 ```
 
 ## Inputs 📥
@@ -90,11 +90,11 @@ jobs:
   json-yaml-validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: json-yaml-validate
         id: json-yaml-validate
-        uses: GrantBirki/json-yaml-validate@vX.X.X # replace with the latest version
+        uses: GrantBirki/json-yaml-validate@v4
 ```
 
 ### Pull Request Comment
@@ -118,11 +118,11 @@ jobs:
   json-yaml-validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: json-yaml-validate
         id: json-yaml-validate
-        uses: GrantBirki/json-yaml-validate@vX.X.X # replace with the latest version
+        uses: GrantBirki/json-yaml-validate@v4
         with:
           comment: "true" # enable comment mode
 ```
@@ -158,10 +158,10 @@ Here is an example of how to use this feature:
 
 ```yaml
 # checkout the repository
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 
 - name: json-yaml-validate
-  uses: GrantBirki/json-yaml-validate@vX.X.X # replace with the latest version
+  uses: GrantBirki/json-yaml-validate@v4
   with:
     yaml_schema: schemas/schema.yml # validate YAML files against the schema
     json_schema: schemas/schema.json # validate JSON files against the schema
@@ -258,7 +258,7 @@ Now that we have a JSON schema that uses custom regex formats and a JSON file th
 
 ```yaml
 - name: json-yaml-validate
-  uses: GrantBirki/json-yaml-validate@vX.X.X # replace with the latest version
+  uses: GrantBirki/json-yaml-validate@v4
   id: json-yaml-validate
   with:
     json_schema: ./schemas/custom_with_regex.json # <--- the schema file that uses custom regex formats
@@ -353,10 +353,10 @@ If the file path to your `exclude_file` is `exclude.txt`, you would set the `exc
 
 ```yaml
 # checkout the repository
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 
 - name: json-yaml-validate
-  uses: GrantBirki/json-yaml-validate@vX.X.X # replace with the latest version
+  uses: GrantBirki/json-yaml-validate@v4
   with:
     exclude_file: exclude.txt # gitignore style file that contains a list of files to exclude
 ```

--- a/docs/yaml_as_json.md
+++ b/docs/yaml_as_json.md
@@ -7,7 +7,7 @@ Here is an example of how to use this feature:
 ```yaml
 - name: json-yaml-validate
   id: json-yaml-validate
-  uses: GrantBirki/json-yaml-validate@vX.X.X # replace with the latest version
+  uses: GrantBirki/json-yaml-validate@v4
   with:
     yaml_as_json: "true" # enable yaml as json mode
 ```


### PR DESCRIPTION
Updates README and docs examples to current action major tags, then pins repository workflow action references to full commit SHAs with `gh pin`.