### PR TITLE
Strengthen branch coverage tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "npm run typecheck",
     "package": "ncc build src/main.ts -o dist --source-map --license licenses.txt",
     "test": "npm run ci-test; test_status=$?; if [ $test_status -eq 0 ]; then node scripts/coverage-badge.js; fi; exit $test_status",
-    "ci-test": "LOCAL_ACTIONS_CI_TEST=true node --import tsx --import ./test/setup.ts --test --test-concurrency=1 --experimental-test-coverage --test-coverage-include='src/**/*.ts' --test-coverage-lines=100 test/*.test.ts test/functions/*.test.ts",
+    "ci-test": "LOCAL_ACTIONS_CI_TEST=true node --import tsx --import ./test/setup.ts --test --test-concurrency=1 --experimental-test-coverage --test-coverage-include='src/**/*.ts' --test-coverage-lines=100 --test-coverage-branches=97 --test-coverage-functions=100 test/*.test.ts test/functions/*.test.ts",
     "all": "npm run typecheck && npm test && npm run package",
     "bundle": "npm run package"
   },

--- a/test/actions-core.test.ts
+++ b/test/actions-core.test.ts
@@ -62,11 +62,13 @@ test('reads multiline inputs and filters blank lines', () => {
 test('emits GitHub command output for logs and legacy outputs', () => {
   core.debug('a%b\nc')
   core.error(new Error('bad'))
+  core.info('plain log')
   core.warning('heads:tails,comma')
   core.setOutput('result', 'ok')
 
   expect(logMock).toHaveBeenCalledWith('::debug::a%25b%0Ac')
   expect(logMock).toHaveBeenCalledWith('::error::bad')
+  expect(logMock).toHaveBeenCalledWith('plain log')
   expect(logMock).toHaveBeenCalledWith('::warning::heads:tails,comma')
   expect(logMock).toHaveBeenCalledWith('::set-output name=result::ok')
 })

--- a/test/functions/process-results.test.ts
+++ b/test/functions/process-results.test.ts
@@ -490,6 +490,34 @@ test('constructs a pull request comment body with both violation sections', asyn
   expect(commentBody).toContain(JSON.stringify(yamlViolations, null, 2))
 })
 
+test('uses the event repository when GITHUB_REPOSITORY is not set for comments', async () => {
+  process.env.INPUT_COMMENT = 'true'
+  delete process.env.GITHUB_REPOSITORY
+
+  expect(
+    await processResults(
+      {
+        success: false,
+        failed: 1,
+        passed: 0,
+        skipped: 0,
+        violations: jsonViolations
+      },
+      {success: true, failed: 0, passed: 1, skipped: 0, violations: []}
+    )
+  ).toBe(false)
+
+  expect(global.fetch).toHaveBeenCalledWith(
+    'https://api.github.com/repos/corp/test/issues/123/comments',
+    expect.objectContaining({
+      method: 'POST'
+    })
+  )
+  expect(setFailedMock).toHaveBeenCalledWith(
+    '❌ JSON or YAML files failed validation'
+  )
+})
+
 test('fails when pull request comment creation fails', async () => {
   process.env.INPUT_COMMENT = 'true'
   global.fetch.mockResolvedValueOnce({

--- a/test/main.test.ts
+++ b/test/main.test.ts
@@ -1,7 +1,39 @@
 import {run} from '../src/main.js'
+import {core} from '../src/actions-core.js'
+
+const setOutputMock = jest.spyOn(core, 'setOutput').mockImplementation(() => {})
+const infoMock = jest.spyOn(core, 'info').mockImplementation(() => {})
 
 beforeEach(() => {
   jest.clearAllMocks()
+  delete process.env.INPUT_FILES
+  delete process.env.INPUT_SCHEMA_MAPPINGS
+  delete process.env.INPUT_JSON_SCHEMA
+  delete process.env.INPUT_YAML_SCHEMA
+  delete process.env.INPUT_JSON_EXCLUDE_REGEX
+  delete process.env.INPUT_YAML_EXCLUDE_REGEX
+  delete process.env.INPUT_GITHUB_TOKEN
+  delete process.env.GITHUB_EVENT_PATH
+  process.env.INPUT_BASE_DIR = '.'
+  process.env.INPUT_JSON_EXTENSION = '.json'
+  process.env.INPUT_YAML_EXTENSION = '.yaml'
+  process.env.INPUT_YAML_EXTENSION_SHORT = '.yml'
+  process.env.INPUT_USE_DOT_MATCH = 'true'
+  process.env.INPUT_YAML_AS_JSON = 'false'
+  process.env.INPUT_ALLOW_MULTIPLE_DOCUMENTS = 'true'
+  process.env.INPUT_USE_INLINE_SCHEMA = 'false'
+  process.env.INPUT_EXCLUDE_FILE = ''
+  process.env.INPUT_EXCLUDE_FILE_REQUIRED = 'false'
+  process.env.INPUT_USE_GITIGNORE = 'false'
+  process.env.INPUT_GIT_IGNORE_PATH = '.gitignore'
+  process.env.INPUT_COMMENT = 'false'
+  process.env.INPUT_COMMENT_ON_SUCCESS = 'false'
+  process.env.INPUT_UPDATE_COMMENT = 'false'
+  process.env.INPUT_MODE = 'fail'
+  process.env.INPUT_AJV_STRICT_MODE = 'true'
+  process.env.INPUT_USE_AJV_FORMATS = 'true'
+  process.env.INPUT_AJV_CUSTOM_REGEXP_FORMATS = ''
+  process.env.INPUT_JSON_SCHEMA_VERSION = 'draft-07'
 })
 
 test('successfully runs the action with injectable dependencies', async () => {
@@ -37,6 +69,18 @@ test('successfully runs the action with injectable dependencies', async () => {
   expect(jsonValidator).toHaveBeenCalledWith(exclude)
   expect(yamlValidator).toHaveBeenCalledWith(exclude)
   expect(processResults).toHaveBeenCalledWith(jsonResults, yamlResults)
+})
+
+test('successfully runs the action with default dependencies', async () => {
+  process.env.INPUT_FILES = '__tests__/fixtures/json/valid/json1.json'
+
+  await run()
+
+  expect(setOutputMock).toHaveBeenCalledWith('success', 'true')
+  expect(infoMock).toHaveBeenCalledWith(
+    '__tests__/fixtures/json/valid/json1.json is valid'
+  )
+  expect(infoMock).toHaveBeenCalledWith('🔎 no YAML files were detected')
 })
 
 test('tests main execution when LOCAL_ACTIONS_CI_TEST is not true', async () => {


### PR DESCRIPTION
## Summary

Adds branch-oriented unit coverage for the production `run()` wiring path and PR comment repository fallback when `GITHUB_REPOSITORY` is unavailable.

Also covers the remaining `actions-core` function gap and tightens `npm run ci-test` so CI now enforces 100% line coverage, at least 97% branch coverage, and 100% function coverage.